### PR TITLE
Fix for 404 on download link

### DIFF
--- a/src/sinon_docs/pages.clj
+++ b/src/sinon_docs/pages.clj
@@ -9,7 +9,7 @@
   (let [version (:version current-release)
         date (:date current-release)]
     (str/replace html "<div class=\"download-link-placeholder\"/>"
-                 (str "<div class=\"button\"><a href=\"releases/sinon-" version
+                 (str "<div class=\"button\"><a href=\"/releases/sinon-" version
                       ".js\">Download Sinon.JS " version "</a></div><p>"
                       date " - <a href=\"Changelog.txt\">Changelog</a> - "
                       "<a href=\"/download/\">More builds/versions</a></p>"))))


### PR DESCRIPTION
Pressing the download link on the sinonjs.org results in a 404. After looking into the issue it is simply a case of a relative link that should have been absolute. Fix: href="releases/sinon-1.14.1.js" => href="/releases/sinon-1.14.1.js"