### PR TITLE
fix typos referring to spy instead of stub

### DIFF
--- a/resources/docs/stubs.edn
+++ b/resources/docs/stubs.edn
@@ -110,8 +110,8 @@
     {:name "stub.yieldsOn(context, [arg1, arg2, ...])"
      :description "Like above but with an additional parameter to pass the `this` context."}
     {:name "stub.yieldsTo(property, [arg1, arg2, ...])"
-     :description "Causes the spy to invoke a callback passed as a property of an object
-        to the spy. Like `yields`, `yieldsTo` grabs the
+     :description "Causes the stub to invoke a callback passed as a property of an object
+        to the stub. Like `yields`, `yieldsTo` grabs the
         first matching argument, finds the callback and calls it with the
         (optional) arguments."}
     {:name "stub.yieldsToOn(property, context, [arg1, arg2, ...])"
@@ -125,14 +125,14 @@
         }
     });
 }"}
-    {:name "spy.yield([arg1, arg2, ...])"
-     :description "Invoke callbacks passed to the `spy` with the given
-        arguments. If the spy was never called with a function argument,
+    {:name "stub.yield([arg1, arg2, ...])"
+     :description "Invoke callbacks passed to the `stub` with the given
+        arguments. If the stub was never called with a function argument,
         `yield` throws an error. Also aliased as
         `invokeCallback`."}
-    {:name "spy.yieldTo(callback, [arg1, arg2, ...])"
+    {:name "stub.yieldTo(callback, [arg1, arg2, ...])"
      :description "Invokes callbacks passed as a property of an object to the
-        spy. Like `yield`, `yieldTo` grabs the first
+        stub. Like `yield`, `yieldTo` grabs the first
         matching argument, finds the callback and calls it with the (optional)
         arguments."
      :example "\"calling callbacks\": function () {
@@ -148,7 +148,7 @@
 
     callback.yieldTo(\"failure\"); // Logs \"Oh noes!\"
 }"}
-    {:name "spy.callArg(argNum)"
+    {:name "stub.callArg(argNum)"
      :description "Like `yield`, but with an explicit argument number
         specifying which callback to call. Useful if a function is called with
         more than one callback, and simply calling the first callback is not
@@ -163,7 +163,7 @@
 
     callback.callArg(1); // Logs \"Oh noes!\"
 }"}
-    {:name "spy.callArgWith(argNum, [arg1, arg2, ...])"
+    {:name "stub.callArgWith(argNum, [arg1, arg2, ...])"
      :description "
         Like `callArg`, but with arguments.
       "}


### PR DESCRIPTION
The docs for the stub functions
- yieldsTo
- yield
- yieldTo
- callArg
- callArgWith

refer to spy instead of stub. This pull request changes spy to stub in these locations.

Note: While writing this pull request, and looking again at the doc, I'm not sure the last 4 methods are real, as they seem to have analogues above them with as yield -> yields, yieldTo -> yieldsTo, callArg ->  callsArg and callArgWith -> callsArgWith.

In which case only the single mention of spy in yieldsTo should be changed and the other 4 should be removed instead of fixed.
