### PR TITLE
Remove Google Analytics

### DIFF
--- a/resources/public/scripts/sinon-web.js
+++ b/resources/public/scripts/sinon-web.js
@@ -1,16 +1,3 @@
-var _gaq = _gaq || [];
-_gaq.push(["_setAccount", "UA-20456066-1"]);
-_gaq.push(["_trackPageview"]);
-
-(function() {
-    var ga = document.createElement("script");
-    ga.type = "text/javascript";
-    ga.async = true;
-    ga.src = ("https:" == document.location.protocol ? "https://ssl" : "http://www") + ".google-analytics.com/ga.js";
-    var s = document.getElementsByTagName("script")[0];
-    s.parentNode.insertBefore(ga, s);
-})();
-
 (function () {
     // Examples
     var examples = document.getElementById("examples");


### PR DESCRIPTION
Nobody is checking it anyway, so there's really no reason to share data with Google or slow down the clients.