### PR TITLE
Fix sinon-timers download link (by pointing to lolex)

### DIFF
--- a/resources/partials/download.html
+++ b/resources/partials/download.html
@@ -15,10 +15,8 @@
         <li><a href="../releases/sinon-ie-${current-version}.js">sinon-ie-${current-version}</a></lI>
       </ul>
       <h3>Stand-alone fake timers</h3>
-      <ul>
-        <li><a href="../releases/sinon-timers-${current-version}.js">sinon-timers-${current-version}</a></lI>
-        <li><a href="../releases/sinon-timers-ie-${current-version}.js">sinon-timers-ie-${current-version}</a></lI>
-      </ul>
+      <p>Now available standalone through the <a href="https://github.com/sinonjs/lolex">lolex</a> project.</p>
+      <p>Install through NPM (npm install lolex) or download it <a href="https://rawgit.com/sinonjs/lolex/master/lolex.js">raw</a></p>
       <h3>Old versions</h3>
       <ul class="old-versions"></ul>
     </div>


### PR DESCRIPTION
Sinon-timers link on the current site 404s because it's been removed from the sinon build (see https://github.com/sinonjs/sinon/issues/811). Now updated to point to lolex, with a link to the raw browser version too (should probably be updated to a specific build once that's in place).
