### PR TITLE
added fake server demo link into #help section

### DIFF
--- a/resources/partials/index.html
+++ b/resources/partials/index.html
@@ -522,6 +522,7 @@ it("returns the return value from the original function", sinon.test(function ()
           <li><a href="http://cjohansen.no/en/javascript/test_spies_stubs_and_mocks_part_1_5">More
               spies, stubs and mocks with Sinon.JS</a></li>
           <li><a href="http://cjohansen.no/en/javascript/javascript_test_spies_stubs_and_mocks">Original Sinon.JS announcement</a></li>
+          <li><a href="https://github.com/ducin/sinon-backend-less-demo">Sinon.JS fake server live demo</a></li>
         </ul>
         <p>
           My book, <a href="http://tddjs.com">Test-Driven JavaScript Development</a>


### PR DESCRIPTION
I have created fake server demos (a simple one and slightly advanced one) for the needs of the presentations and trainings I do. I couldn't find such resource out in the web.

Hope it'd be useful for Sinon.JS users. I'd be glad if you add it into the `#help` section